### PR TITLE
fix(style): update dark mode link & input contrast

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,10 +1,12 @@
 import styles from '@/styles/Home.module.css'
-import { Text } from '@chakra-ui/react'
+import { Text, useColorModeValue } from '@chakra-ui/react'
 
 export default function Footer() {
+  const dynamicLinkColor = useColorModeValue('blue.600', 'blue.400')
+
   return (
     <footer className={styles.footer}>
-      <Text color="blue.600" fontSize="sm">
+      <Text color={dynamicLinkColor} fontSize="sm">
         <a
           href="https://github.com/agallio/ina-covid-bed"
           target="_blank"

--- a/components/SearchProvince.js
+++ b/components/SearchProvince.js
@@ -44,7 +44,8 @@ function SearchProvince({ onChooseProvince, onSearchGeo, disabled, value }) {
   const [inputProvince, setInputProvince] = useState('')
   const [filterResult, setFilterResult] = useState([])
 
-  const dynamicInputColor = useColorModeValue('gray.300', 'white')
+  const dynamicInputColor = useColorModeValue('gray.900', 'white')
+  const dynamicPlaceholderColor = useColorModeValue('gray.500', 'gray.400')
 
   function handleKeyPress(e) {
     if (e.code === 'Enter' && filterResult.length > 0) {
@@ -94,6 +95,7 @@ function SearchProvince({ onChooseProvince, onSearchGeo, disabled, value }) {
             onKeyPress={handleKeyPress}
             onChange={handleOnChange}
             color={dynamicInputColor}
+            _placeholder={{ color: dynamicPlaceholderColor }}
           />
         </InputGroup>
         <Button

--- a/pages/[province].js
+++ b/pages/[province].js
@@ -10,6 +10,7 @@ import {
   HStack,
   Text,
   Spinner,
+  useColorModeValue,
 } from '@chakra-ui/react'
 
 import useHospitalDataByProvince from '@/hooks/useHospitalDataByProvince'
@@ -31,6 +32,8 @@ function ProvincePage(props) {
       .slice(0, 3)
       .filter((p) => p.value !== province)
   }
+
+  const dynamicLinkColor = useColorModeValue('blue.600', 'blue.400')
 
   const isLoading = !Boolean(hospitalList)
 
@@ -56,7 +59,7 @@ function ProvincePage(props) {
       />
 
       <Container py="10">
-        <Text color="blue.600" fontSize="sm">
+        <Text color={dynamicLinkColor} fontSize="sm">
           <Link href="/" passHref>
             <ChakraLink>‹ Ganti Provinsi</ChakraLink>
           </Link>
@@ -76,7 +79,7 @@ function ProvincePage(props) {
             >
               <Text>Provinsi sekitar:</Text>
               {alternativeProvinces.map((alternative) => (
-                <Text key={alternative.value} color="blue.600">
+                <Text key={alternative.value} color={dynamicLinkColor}>
                   <Link
                     passHref
                     href={`/${alternative.value}?geo=${lat},${lon}`}


### PR DESCRIPTION
closes #31

Modified elements:

- Link color in Footer and Province page
    - light: `blue.600`
    - dark: `blue.400`

- Input text color in SearchProvince component
    - light: `gray.900`
    - dark: `white`

- Input placeholder color in SearchProvince component
    - light: `gray.500`
    - dark: `gray.400`
