### PR TITLE
add info text when get long response api request

### DIFF
--- a/hooks/useHospitalDataByProvince.js
+++ b/hooks/useHospitalDataByProvince.js
@@ -1,13 +1,26 @@
 import useSWR from 'swr'
+import { useState } from 'react'
 
 import { getDistanceFromLatLonInKm } from '@/utils/LocationHelper'
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json())
 
 export default function useHospitalDataByProvince(province, geo) {
+  const [slowLoading, setSlowLoading] = useState(false)
   const { data: apiResult } = useSWR(
     `/api/bed?prov=${province}&revalidate=false`,
-    fetcher
+    fetcher,
+    {
+      loadingTimeout: 10000,
+      onLoadingSlow: () => {
+        setSlowLoading(true)
+        return
+      },
+      onSuccess: () => {
+        setSlowLoading(false)
+        return
+      },
+    }
   )
   let hospitalList = null
   let bedFull = false
@@ -53,7 +66,8 @@ export default function useHospitalDataByProvince(province, geo) {
           return a.distance > b.distance ? 1 : -1
         })
     }
+    // setSlowLoading(false)
   }
 
-  return { bedFull, hospitalList }
+  return { bedFull, hospitalList, slowLoading }
 }

--- a/pages/[province].js
+++ b/pages/[province].js
@@ -151,9 +151,10 @@ function ProvincePage(props) {
             <Box w="100%" textAlign="center">
               <Spinner size="lg" />
               {slowLoading && (
-                <Text p={4} mt={4}>
-                  Pengambilan data Provinsi {getProvinceDisplayName(province)}{' '}
-                  membutuhkan waktu lebih lama. Mohon tunggu.{' '}
+                <Text px={2} py={4} mt={4}>
+                  Pengambilan data provinsi &quot;
+                  {getProvinceDisplayName(province)}&quot; membutuhkan waktu
+                  yang lebih lama. Mohon tunggu sesaat.{' '}
                 </Text>
               )}
             </Box>

--- a/pages/[province].js
+++ b/pages/[province].js
@@ -34,6 +34,7 @@ function ProvincePage(props) {
   const isShowAlternativeProvince = !!geo
   const [hospitals, setHospitals] = useState([])
   const [searchValue, setSearchValue] = useState('')
+  const [seconds, setSeconds] = useState(0)
 
   const refreshHospitals = () => {
     setHospitals(hospitalList || [])
@@ -71,6 +72,18 @@ function ProvincePage(props) {
   const dynamicLinkColor = useColorModeValue('blue.600', 'blue.400')
 
   const isLoading = !Boolean(hospitalList)
+
+  useEffect(() => {
+    let timer
+    if (isLoading) {
+      timer = setTimeout(() => {
+        setSeconds((seconds) => seconds + 1)
+      }, 1000)
+    } else if (!isLoading && seconds !== 0) {
+      clearTimeout(timer)
+    }
+    return () => clearTimeout(timer)
+  }, [isLoading, seconds])
 
   return (
     <>
@@ -147,6 +160,12 @@ function ProvincePage(props) {
           ) : (
             <Box w="100%" textAlign="center">
               <Spinner size="lg" />
+              {seconds > 10 && (
+                <Text p={4} mt={4}>
+                  Pengambilan data Provinsi {getProvinceDisplayName(province)}{' '}
+                  membutuhkan waktu lebih lama. Mohon tunggu.{' '}
+                </Text>
+              )}
             </Box>
           )}
 

--- a/pages/[province].js
+++ b/pages/[province].js
@@ -30,11 +30,13 @@ function ProvincePage(props) {
   const { province } = props
   const [lat, lon] = (props.geo ?? '').split(',')
   const geo = props.geo ? { lat, lon } : null
-  const { bedFull, hospitalList } = useHospitalDataByProvince(province, geo)
+  const { bedFull, hospitalList, slowLoading } = useHospitalDataByProvince(
+    province,
+    geo
+  )
   const isShowAlternativeProvince = !!geo
   const [hospitals, setHospitals] = useState([])
   const [searchValue, setSearchValue] = useState('')
-  const [seconds, setSeconds] = useState(0)
 
   const refreshHospitals = () => {
     setHospitals(hospitalList || [])
@@ -72,18 +74,6 @@ function ProvincePage(props) {
   const dynamicLinkColor = useColorModeValue('blue.600', 'blue.400')
 
   const isLoading = !Boolean(hospitalList)
-
-  useEffect(() => {
-    let timer
-    if (isLoading) {
-      timer = setTimeout(() => {
-        setSeconds((seconds) => seconds + 1)
-      }, 1000)
-    } else if (!isLoading && seconds !== 0) {
-      clearTimeout(timer)
-    }
-    return () => clearTimeout(timer)
-  }, [isLoading, seconds])
 
   return (
     <>
@@ -160,7 +150,7 @@ function ProvincePage(props) {
           ) : (
             <Box w="100%" textAlign="center">
               <Spinner size="lg" />
-              {seconds > 10 && (
+              {slowLoading && (
                 <Text p={4} mt={4}>
                   Pengambilan data Provinsi {getProvinceDisplayName(province)}{' '}
                   membutuhkan waktu lebih lama. Mohon tunggu.{' '}


### PR DESCRIPTION
Hi @agallio, this is my attempt on the #44 issue.
I'm creating a simple timer using `useEffect` and `setTimeout` to check whether the loading passes 10secs and trigger the text visibility.
Let me know what do you think. Feel free to give any suggestions on a better approach. 🙏 

![image](https://user-images.githubusercontent.com/3627108/126281600-1f8a7d4b-2fa5-447a-a87d-6f7db63463d4.gif)

note: the gif above is not the updated version. But I've pulled the latest PR for this commit.
