### PR TITLE
Adjust safari map height and alternative location margin

### DIFF
--- a/pages/[province].js
+++ b/pages/[province].js
@@ -102,12 +102,12 @@ function ProvincePage(props) {
             <ChakraLink>‹ Ganti Provinsi</ChakraLink>
           </Link>
         </Text>
-        <VStack spacing="1" my="12">
+        <VStack spacing="4" my="12">
           <Text>Ketersediaan tempat tidur rumah sakit</Text>
           <Heading m="4" textAlign="center">
             {getProvinceDisplayName(province)}
           </Heading>
-          <br />
+
           <InputGroup>
             <InputLeftElement
               pointerEvents="none"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Container, Flex } from '@chakra-ui/react'
 import SearchProvince from '@/components/SearchProvince'
 import { VStack, Box, Heading, Button } from '@chakra-ui/react'
@@ -8,6 +8,7 @@ import { getNearestProvince } from '@/utils/LocationHelper'
 export default function Home() {
   const router = useRouter()
   const [isSearchingGeo, setSearchingGeo] = useState(false)
+  const [wrapperHeight, setWrapperHeight] = useState('90vh')
 
   function toMapPage() {
     router.push('/map')
@@ -40,9 +41,13 @@ export default function Home() {
     )
   }
 
+  useEffect(() => {
+    setWrapperHeight(window.innerHeight * 0.9)
+  }, [])
+
   return (
     <Container>
-      <Flex h="90vh" justify="center" align="center">
+      <Flex h={wrapperHeight} justify="center" align="center">
         <VStack w="100%" spacing="8">
           <Heading as="h1" fontSize="3xl" textAlign="center">
             Ketersediaan Tempat Tidur Rumah Sakit

--- a/pages/map.js
+++ b/pages/map.js
@@ -38,6 +38,7 @@ function MapPage(props) {
   })
   const [popupHospital, setPopupHospitalVisibility] = useState(false)
   const [_, setSearchingGeo] = useState(false)
+  const [mapWrapperHeight, setMapWrapperHeight] = useState(0)
 
   const [urlLat, urlLon] = (props.geo ?? '').split(',')
   const geo = props.geo ? { lat: urlLat, lon: urlLon } : null
@@ -70,6 +71,10 @@ function MapPage(props) {
   useEffect(() => {
     updateMap()
   }, [hospitalList])
+
+  useEffect(() => {
+    setMapWrapperHeight(window.innerHeight - 70)
+  }, [])
 
   const handleChooseProvince = (province, type = 'auto') => {
     setProvince({ value: province.value, label: province.name })
@@ -263,7 +268,7 @@ function MapPage(props) {
       <Box
         position="relative"
         width="100vw"
-        height="calc(100vh - 70px)"
+        height={mapWrapperHeight}
         overflow="hidden"
       >
         <Box ref={mapContainer} height="100%" width="100%" />


### PR DESCRIPTION
Might close #50 and #45

### Before 
<img width="352" alt="Screen Shot 2021-07-26 at 19 32 38" src="https://user-images.githubusercontent.com/16324649/126989226-08d94c4a-d222-456c-b515-a133644eecd8.png">

<img width="373" alt="Screen Shot 2021-07-26 at 19 08 59" src="https://user-images.githubusercontent.com/16324649/126986977-6db84fbb-67bf-48b7-8c0f-7da87e401607.png">

<img width="704" alt="Screen Shot 2021-07-26 at 19 14 11" src="https://user-images.githubusercontent.com/16324649/126986989-a09d3230-471e-4d11-b490-c50e118685a0.png">

### After
<img width="362" alt="Screen Shot 2021-07-26 at 19 32 28" src="https://user-images.githubusercontent.com/16324649/126989237-3a68940c-71b5-4c93-bdbc-05f34fe33249.png">

<img width="667" alt="Screen Shot 2021-07-26 at 19 14 00" src="https://user-images.githubusercontent.com/16324649/126987022-17a77d81-fc33-4202-932a-f3e0d344e879.png">
<img width="382" alt="Screen Shot 2021-07-26 at 19 08 34" src="https://user-images.githubusercontent.com/16324649/126987035-abc8c343-06f1-48ff-a56f-863ec59504db.png">
